### PR TITLE
feat(validation): can specify required object props

### DIFF
--- a/src/validation.d.ts
+++ b/src/validation.d.ts
@@ -1,3 +1,4 @@
+import { Required } from 'simplytyped';
 import { StringSchema } from './defs/string';
 import { NumberSchema } from './defs/number';
 import { BooleanSchema } from './defs/boolean';
@@ -7,14 +8,19 @@ import { ObjectSchema } from './defs/object';
 import { EnumSchema, AllOf, AnyOf, OneOf, Not, Ref } from './defs/other';
 import { SchemaDefinition } from './index';
 
-// validate object typed schemas
 type SchematizeProperties<S extends ObjectSchema> = S['properties'] extends Record<string, SchemaDefinition> ? {
-    [K in keyof S['properties']]: Schematize1<S['properties'][K]>;
+    [K in keyof S['properties']]?: Schematize1<S['properties'][K]>;
 } : object;
+
+type MarkRequired<S extends ObjectSchema, P extends object> = S['required'] extends any[] ?
+    Required<P, S['required'][number]> : P;
+
+// validate object typed schemas
+type SchematizeObject<S extends ObjectSchema> = MarkRequired<S, SchematizeProperties<S>>;
 
 // validate array typed schemas
 type SchematizeItems<S extends TupleSchema | ArraySchema> = {
-    [K: number]: S['items'] extends SchemaDefinition ? Schematize1<S['items']> : any;
+    [K: number]: S['items'] extends SchemaDefinition ? Schematize1<S['items']> : any[];
 }
 
 // validate string typed schemas
@@ -26,11 +32,11 @@ type Schematize1<S extends SchemaDefinition> =
     S extends NumberSchema ? number :
     S extends BooleanSchema ? boolean :
     S extends ArraySchema | TupleSchema ? SchematizeItems<S> :
-    S extends ObjectSchema ? SchematizeProperties<S> : any;
+    S extends ObjectSchema ? SchematizeObject<S> : any;
 
 export type Schematize<S extends SchemaDefinition> =
     S extends StringSchema ? SchematizeString<S> :
     S extends NumberSchema ? number :
     S extends BooleanSchema ? boolean :
     S extends ArraySchema | TupleSchema ? SchematizeItems<S> :
-    S extends ObjectSchema ? SchematizeProperties<S> : any;
+    S extends ObjectSchema ? SchematizeObject<S> : any;

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -110,6 +110,18 @@ test('object of objects', assertValidations(
     },
 ));
 
+test('objects can have required properties', assertValidations(
+    {
+        type: 'object',
+        properties: {
+            merp: { type: 'string' },
+            opt: { type: 'string' },
+        },
+        required: ['merp' as 'merp'],
+    },
+    { merp: 'hey' },
+));
+
 // -------
 // Strings
 // -------


### PR DESCRIPTION
Make sure that objects have optional properties by default. Can specify required properties using the `required` field.