### PR TITLE
refactor(validation): remove Schematize duplication

### DIFF
--- a/src/validation.d.ts
+++ b/src/validation.d.ts
@@ -9,7 +9,7 @@ import { EnumSchema, AllOf, AnyOf, OneOf, Not, Ref } from './defs/other';
 import { SchemaDefinition } from './index';
 
 type SchematizeProperties<S extends ObjectSchema> = S['properties'] extends Record<string, SchemaDefinition>
-    ? { [K in keyof S['properties']]?: Schematize1<S['properties'][K]> }
+    ? { [K in keyof S['properties']]?: Schematize<S['properties'][K]> }
     : object;
 
 type MarkRequired<S extends ObjectSchema, P extends object> = S['required'] extends any[]
@@ -22,7 +22,7 @@ type SchematizeObject<S extends ObjectSchema> = MarkRequired<S, SchematizeProper
 // validate array typed schemas
 type SchematizeItems<S extends TupleSchema | ArraySchema> = {
     [K: number]: S['items'] extends SchemaDefinition
-        ? Schematize1<S['items']>
+        ? Schematize<S['items']>
         : any;
 }
 
@@ -30,15 +30,6 @@ type SchematizeItems<S extends TupleSchema | ArraySchema> = {
 type SchematizeString<S extends StringSchema> = S['enum'] extends string[]
     ? UnionizeTuple<S['enum']>
     : string;
-
-// this duplicates Schematize to allow arbitrary recursion depth without TS complaining about circular references
-type Schematize1<S extends SchemaDefinition> =
-    S extends StringSchema ? SchematizeString<S> :
-    S extends NumberSchema ? number :
-    S extends BooleanSchema ? boolean :
-    S extends NullSchema ? null | undefined :
-    S extends ArraySchema | TupleSchema ? SchematizeItems<S> :
-    S extends ObjectSchema ? SchematizeObject<S> : any;
 
 export type Schematize<S extends SchemaDefinition> =
     S extends StringSchema ? SchematizeString<S> :


### PR DESCRIPTION
We were duplicating the Schematize type to allow for arbitrary recursion
depth. It appears that this wasn't necessary, it allowed us to get
around an issue with SchematizeItems where generating an array caused
self referential issues. By moving SchematizeItems to using an interface
with numeric keys (nearly equivalent to an array) we allow ourselves to
clean up the Schematize duplicated code.